### PR TITLE
Added container_name to solve 'no such container' errors

### DIFF
--- a/Examples/docker-compose.yml
+++ b/Examples/docker-compose.yml
@@ -28,6 +28,7 @@ services:
   private:
     image: itzg/minecraft-bedrock-server
     restart: always
+    container_name: bedrock_private
     environment:
       EULA: "TRUE"
     ports:
@@ -42,6 +43,7 @@ services:
   public:
     image: itzg/minecraft-bedrock-server
     restart: always
+    container_name: bedrock_public
     environment:
       EULA: "TRUE"
     ports:

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ In your `docker-compose.yml` file where you configure your minecraft server, you
       - /opt/bedrock/server:/server
 ```
 
-The service should always depend on all the bedrock servers listed in your `docker-compose.yml` file. We want to let the minecraft servers start before taking a backup on launch. 
+The service should always depend on all the bedrock servers listed in your `docker-compose.yml` file. We want to let the minecraft servers start before taking a backup on launch. You may also consider setting a `container_name` for each server that will be backed up as somes Docker will assign a different container name with a prefix.
 
 For the volumes, we need to configure them this way:
 * Map in `docker.sock`. The above example should work fine for when docker runs as root. When running rootless, take the value you found earlier and include it like so: `/run/user/1000/docker.sock:/var/run/docker.sock`

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ In your `docker-compose.yml` file where you configure your minecraft server, you
       - /opt/bedrock/server:/server
 ```
 
-The service should always depend on all the bedrock servers listed in your `docker-compose.yml` file. We want to let the minecraft servers start before taking a backup on launch. You may also consider setting a `container_name` for each server that will be backed up as somes Docker will assign a different container name with a prefix.
+The service should always depend on all the bedrock servers listed in your `docker-compose.yml` file. We want to let the minecraft servers start before taking a backup on launch. It is recommended to set `container_name` for each server that will be backed up as docker-compose will assign one automatically if it isn’t set, and this simplifies configuring the backup service. 
 
 For the volumes, we need to configure them this way:
 * Map in `docker.sock`. The above example should work fine for when docker runs as root. When running rootless, take the value you found earlier and include it like so: `/run/user/1000/docker.sock:/var/run/docker.sock`


### PR DESCRIPTION
Updating example file and documentation regarding #2 as I ran into that as well.