### PR TITLE
Prevent automatic exit on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Container no longer exits when a backup fails, avoiding a restart loop.
+- A running container will be marked unhealthy if backups are failing.
 
 #### Dec 1st, 2021
 - Fixes for 1.18 servers that caused recurring backups.

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && \
     && rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT ["/usr/local/bin/entrypoint-demoter", "--match", "/backups", "--debug", "--stdin-on-term", "stop", "/opt/bedrock/entry.sh"]
-HEALTHCHECK --interval=5m --timeout=1s CMD /opt/bedrock/healthcheck.sh
+HEALTHCHECK --start-period=1m CMD /opt/bedrock/healthcheck.sh
 
 ARG EASY_ADD_VERSION=0.7.0
 ADD https://github.com/itzg/easy-add/releases/download/${EASY_ADD_VERSION}/easy-add_linux_${ARCH} /usr/local/bin/easy-add

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update && \
     && rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT ["/usr/local/bin/entrypoint-demoter", "--match", "/backups", "--debug", "--stdin-on-term", "stop", "/opt/bedrock/entry.sh"]
+HEALTHCHECK --interval=5m --timeout=1s CMD /opt/bedrock/healthcheck.sh
 
 ARG EASY_ADD_VERSION=0.7.0
 ADD https://github.com/itzg/easy-add/releases/download/${EASY_ADD_VERSION}/easy-add_linux_${ARCH} /usr/local/bin/easy-add
@@ -36,4 +37,5 @@ RUN easy-add --var version=0.2.1 --var app=entrypoint-demoter --file {{.app}} --
 
 COPY --from=builder /project/.build/release/BedrockifierCLI .
 COPY entry.sh .
+COPY healthcheck.sh .
 

--- a/entry.sh
+++ b/entry.sh
@@ -19,6 +19,12 @@ while true; do
   # Fire backup via BedrockifierCLI Tool
   /opt/bedrock/BedrockifierCLI backupjob "${DATA_DIR}/${CONFIG_FILE}" --dockerPath "${DOCKER_PATH}" --backupPath "${DATA_DIR}" >&2
 
+  if [ $? != 0 ]; then
+    touch "${DATA_DIR}/unhealthy"
+  elif [ -e "${DATA_DIR}/unhealthy" ]; then
+    rm "${DATA_DIR}/unhealthy"
+  fi
+
   # If BACKUP_INTERVAL is not a valid number (i.e. 24h), we want to sleep.
   # Only raw numeric value <= 0 will break
   if (( BACKUP_INTERVAL <= 0 )) &>/dev/null; then

--- a/entry.sh
+++ b/entry.sh
@@ -4,7 +4,7 @@
 #
 # Used by the docker container
 
-set -euo pipefail
+set -uo pipefail
 
 if [ "${DEBUG:-false}" == "true" ]; then
   set -x

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# Backup Job Healthcheck
+#
+# Used by the docker container
+
+set -uo pipefail
+
+if [ "${DEBUG:-false}" == "true" ]; then
+  set -x
+fi
+
+: "${DATA_DIR:=/backups}"
+
+if [ -e "${DATA_DIR}/unhealthy" ]; then
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
* Disables the automatic exit on backup failure that was configured in the entry script.
* Enables basic health check support in docker, so the container can be marked as unhealthy on failure instead.