### PR TITLE
Remove TTY Requirement / Upgrade Swift to 5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-#### Dec 13th, 2021
+- Updated to Swift 5.5 compiler.
+- The property "tty: true" is no longer required on the server container.
+
+#### v1.0.2 - Dec 13th, 2021
 - Container no longer exits when a backup fails, avoiding a restart loop.
 - A running container will be marked unhealthy if backups are failing.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ###### BUILDER
-FROM swift:5.4 as builder
+FROM swift:5.5 as builder
 WORKDIR /project
 
 ARG COMMIT=main
@@ -14,7 +14,7 @@ RUN git checkout ${COMMIT}
 RUN swift build -c release
 
 ###### RUNTIME CONTAINER
-FROM swift:5.4-slim
+FROM swift:5.5-slim
 
 ARG ARCH=amd64
 

--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,10 @@
 TAG=${1:-dev}
 COMMIT=${2:-main}
 
+# Build
+#
+# QEMU_CPU needs to be set to max when building on Apple Silicon.
+# Cuts down on illegal instruction errors.
 docker build . \
     --platform linux/amd64 \
     -t kaiede/minecraft-bedrock-backup:${TAG} \

--- a/build.sh
+++ b/build.sh
@@ -8,5 +8,6 @@ COMMIT=${2:-main}
 docker build . \
     --platform linux/amd64 \
     -t kaiede/minecraft-bedrock-backup:${TAG} \
+    --build-arg QEMU_CPU=max \
     --build-arg CACHEBUST=$(date +%s) \
     --build-arg COMMIT=${COMMIT}


### PR DESCRIPTION
Updates the build to use the Swift 5.5 compiler.

Also grabs the latest BedrockifierCLI which includes changes that remove the TTY requirement.