### PR TITLE
Update Docs Now That Ownership Appears to Work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 #### In 'test'
 - Updated to Swift 5.5 compiler.
 - The property "tty: true" is no longer required on the server container.
-- EXPERIMENTAL: New "ownership" configuration for the backup allows changing the owner, group, and permissions on backups written. May cause problems with backup trimming if not configured correctly.
+- New "ownership" configuration for the backup allows changing the owner, group, and permissions on backups written. Changing the owner and group requires running as root, which isn't recommended. Trimming also may not work properly if the backup tool loses write access. Use with caution.
 
 #### v1.0.2 - Dec 13th, 2021
 - Container no longer exits when a backup fails, avoiding a restart loop.

--- a/doc/PERMISSIONS.md
+++ b/doc/PERMISSIONS.md
@@ -14,7 +14,7 @@ In cases where you need to override the user and group that is picked for you by
 
 ### Overriding Permissions on Backed Up Worlds
 
-In the `config.json`, there is an **EXPERIMENTAL** feature that allows you to override the user, group, and permissions for the backups. It is only recommended to do this if you absolutely have to, such as running it on a NAS device that requires specific ownership and permissions.
+In the `config.json`, there is a feature that allows you to override the user, group, and permissions for the backups. It is only recommended to do this if you absolutely have to, such as running it on a NAS device that requires specific ownership and permissions. Trimming may break if the tool loses write access to the backup files. Use with caution.
 
 **Using chown requires running the service as root which is not recommended!**
 

--- a/doc/TOOL_CONFIG.md
+++ b/doc/TOOL_CONFIG.md
@@ -37,11 +37,11 @@ It is controlled by the following settings:
 
 * `minKeep`: A minimum number of backups to keep. This is useful if you switch worlds on your server, as it will make sure you always have a couple backups of any world even if it hasn't been used in a while. This will override keepDays, and let you keep at least this many backups indefinitely.
 
-### Ownership (EXPERIMENTAL)
+### Ownership
 
 This is meant for the rare cases where files on disk need to be a very specific user and group, and/or have specific permissions. NAS devices being one example. It allows you to tell the service how to set ownership and permissions on the backups written to disk.
 
-This functionality may break trimming of backups if it causes the service to no longer be able to have write permissions to the backups.
+This functionality may break trimming of backups if it causes the service to no longer be able to have write permissions to the backups. Use with caution.
 
 * `chown`: This sets the owner and group on backed up mcworld files. It works much like the `chown` command's argument, but only accepts ids, not names. **Using this requires the service to run as root which is not recommended.**
 


### PR DESCRIPTION
BedrockifierCLI now has support for ownership that appears to be working on Ubuntu hosts. So we can close out #11 once this hits the test tag. 